### PR TITLE
Fixed android resource linking failure

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion 28
+    buildToolsVersion "28.0.3"
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 22
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
         ndk {


### PR DESCRIPTION
Ref: https://github.com/yamill/react-native-orientation/issues/369

The android build failed with the following error:

```
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':react-native-orientation:verifyReleaseResources'.
> 1 exception was raised by workers:
  com.android.builder.internal.aapt.v2.Aapt2Exception: Android resource linking failed
```

Therefore, upgraded compileSdkVersion fix it.